### PR TITLE
Sqlalchemy refactor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,76 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Python cache files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environment directories
+venv/
+.env/
+
+# Test-related files
+**/.pytest_cache/
+
+# Git and CI files
+.git/
+.github/
+.gitignore
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IDEs
+.idea
+**/*.swp
+.vscode/
+
+# db files
+**/*.db

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ of a configuration file
 **Example Configuration**
 
 ```yaml
-db_file_path: clutchtime.db
-db_table_name: clutchgames
+db_url: clutchtime.db
 notifications:
   - type: GroupMe
     config:
@@ -96,9 +95,7 @@ notifications:
 
 ### YAML Fields
 
-**db_file_path** (__Optional__): Path to sqllite database to store game data. Defaults to clutchtime.db
-
-**db_table_name** (__Optional__):  SQLite table name to store data in. Default to clutchgames
+**db_url** (__Optional__): DB url to sqlite3 database. Defaults to sqlite:///clutchtime.db
 
 **notifications**: List of notification configs
 -  **type**: class name or common name of the alert type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,20 @@ description = "Default template for PDM package"
 authors = [
     {name = "Brian Walheim", email = "bri125521@gmail.com"},
 ]
-dependencies = ["requests>=2.32.3", "slack-sdk>=3.33.3", "pyyaml>=6.0.2", "twilio>=9.3.8"]
+dependencies = [
+    "requests>=2.32.3", 
+    "slack-sdk>=3.34.0", 
+    "pyyaml>=6.0.2", 
+    "twilio>=9.4.1", 
+    "sqlalchemy>=2.0.36"
+]
 requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "MIT"}
 
 
 [dependency-groups]
-lint = ["pre-commit>=4.0.1", "ruff>=0.7.2"]
+lint = ["pre-commit>=4.0.1", "ruff>=0.8.6"]
 tests = [
     "pytest>=8.3.4",
 ]

--- a/src/clutchtimealerts/__main__.py
+++ b/src/clutchtimealerts/__main__.py
@@ -48,7 +48,6 @@ if __name__ == "__main__":
 
     alert_service = ClutchAlertsService(
         notifications=parser.notifications,
-        db_path=parser.db_file_path,
-        db_table_name=parser.db_table_name,
+        db_url=parser.db_url,
     )
     alert_service.run()

--- a/src/clutchtimealerts/config_parser.py
+++ b/src/clutchtimealerts/config_parser.py
@@ -22,8 +22,7 @@ class ConfigParser:
             config = yaml.safe_load(f)
 
         # Parse database file path
-        self.db_file_path = config.get("db_file_path", "clutchtime.db")
-        self.db_table_name = config.get("db_table_name", TABLE_NAME)
+        self.db_url = config.get("db_url", "sqlite:///clutchtime.db")
 
         notification_configs = config.get("notifications", [])
         self.notifications = []

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -19,8 +19,7 @@ class MockNotification(Notification):
 def sample_config():
     """Fixture for a sample configuration YAML."""
     return """
-    db_file_path: "test.db"
-    db_table_name: "test_table"
+    db_url: "test.db"
     notifications:
       - type: email
         config:
@@ -56,8 +55,7 @@ def test_parse_config_valid_config(
 ):
     """Test parsing a valid configuration file."""
     mock_yaml_load.return_value = {
-        "db_file_path": "test.db",
-        "db_table_name": "test_table",
+        "db_url": "test.db",
         "notifications": [
             {"type": "email", "config": {"recipient": "test@example.com"}},
             {"type": "sms", "config": {"phone_number": "+123456789"}},
@@ -72,8 +70,7 @@ def test_parse_config_valid_config(
     parser.parse_config()
 
     # Check database path and table name
-    assert parser.db_file_path == "test.db"
-    assert parser.db_table_name == "test_table"
+    assert parser.db_url == "test.db"
 
     # Check notifications
     assert len(parser.notifications) == 2


### PR DESCRIPTION
# Overview

This PR doesn't cover any new functionality. It covers refactoring the database_util functions to use SQL alchemy instead of sqlite. This could allow support for different databases in the future, but this is not tested. 

# Changes
- Rewrite of database_utils.py to use sqlalchemy
- Modifying config_parser to use database_url
- Adding .dockerignore