### PR TITLE
Custom Team Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,15 @@ of a configuration file
 
 ```yaml
 db_url: clutchtime.db
-notification_format: 
 
 notifications:
   - type: GroupMe
     config:
       bot_id: "<group-bot-id>"
   - type: Slack
+    nba_teams:
+        - PHI
+        - MIL
     config:
       channel: "#general"
       token: "<slack-api-token>"
@@ -103,10 +105,13 @@ notifications:
 
 **ot_format** (__Optional__): fstring for formatting ot alert messages. Defaults to "OT{OT_NUMBER} Alert\n{HOME_TEAM_TRI} {HOME_TEAM_SCORE} - {AWAY_TEAM_SCORE} {AWAY_TEAM_TRI}\n{NBA_COM_STREAM}"
 
+**nba_teams** (__Optional__): a list of NBA team tricodes that you wish to receive notifications list. Defaluts to all NBA teams
+
 **notifications**: List of notification configs
 -  **type**: class name or common name of the alert type
 -  **notification_format** (__Optional__): fstring for formatting clutch alert messages overwrites global level config.
-- **ot_format** (__Optional__): fstring for formatting ot alert messages. Overwrites global level config
+-  **ot_format** (__Optional__): fstring for formatting ot alert messages. Overwrites global level config
+-  **nba_teams** (__Optional__): a list of NBA team tricodes that you wish to receive notifications list. Overwrites global level config
 -  **config**: kwargs** for the alert classes
 
 ### Format Langauge

--- a/src/clutchtimealerts/clutch_alerts.py
+++ b/src/clutchtimealerts/clutch_alerts.py
@@ -48,7 +48,7 @@ class ClutchAlertsService:
             # Check if team in nba teams
             if (
                 game["homeTeam"]["teamTricode"] in notification_config.nba_teams
-                and game["awayTeam"]["teamTricode"] in notification_config.nba_teams
+                or game["awayTeam"]["teamTricode"] in notification_config.nba_teams
             ):
                 # Format message
                 try:

--- a/src/clutchtimealerts/clutch_alerts.py
+++ b/src/clutchtimealerts/clutch_alerts.py
@@ -45,28 +45,33 @@ class ClutchAlertsService:
         None
         """
         for notification_config in self.notification_configs:
-            # Format message
-            try:
-                if alert_type == "ot":
-                    message = format_message(game, notification_config.ot_format)
-                elif alert_type == "clutch":
-                    message = format_message(
-                        game, notification_config.notification_format
+            # Check if team in nba teams
+            if (
+                game["homeTeam"]["teamTricode"] in notification_config.nba_teams
+                and game["awayTeam"]["teamTricode"] in notification_config.nba_teams
+            ):
+                # Format message
+                try:
+                    if alert_type == "ot":
+                        message = format_message(game, notification_config.ot_format)
+                    elif alert_type == "clutch":
+                        message = format_message(
+                            game, notification_config.notification_format
+                        )
+                except Exception:
+                    logger.error(
+                        f"Error formatting message for {notification_config.notification.__class__.__name__}"
                     )
-            except Exception:
-                logger.error(
-                    f"Error formatting message for {notification_config.notification.__class__.__name__}"
-                )
-                continue
+                    continue
 
-            # Send message with notification
-            logger.debug(f"Sending message: {message}")
-            try:
-                notification_config.notification.send(message)
-            except Exception as e:
-                logger.error(
-                    f"Error sending notification to {notification_config.notification.__class__.__name__}: {e}"
-                )
+                # Send message with notification
+                logger.debug(f"Sending message: {message}")
+                try:
+                    notification_config.notification.send(message)
+                except Exception as e:
+                    logger.error(
+                        f"Error sending notification to {notification_config.notification.__class__.__name__}: {e}"
+                    )
 
     def _get_minutes_from_clock(self, clock) -> int:
         """

--- a/src/clutchtimealerts/notifications/base.py
+++ b/src/clutchtimealerts/notifications/base.py
@@ -15,3 +15,4 @@ class NotificationConfig:
     notification: Notification
     notification_format: str
     ot_format: str
+    nba_teams: set[str]


### PR DESCRIPTION
# Overview
This PR covers the a new feature for team customization. It allows users to configure notifications to only report specific teams. This is configurable at the global and notification level. It is specified using the **nba_teams** keyword.

## Changes

- Updated ClutchAlertsService to include send logic for team
- Updated ConfigParser to include nba_teams keyword
- Updated NotificationConfig class to include nba_teams keyword
- Updated config_parser tests
- Updated README.md

## Related Issues
Closes #14 