### PR TITLE
19 - Fix OT Multiple Alert Bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clutchtimealerts"
-version = "0.2.0"
+version = "0.2.1"
 description = "Default template for PDM package"
 authors = [
     {name = "Brian Walheim", email = "bri125521@gmail.com"},

--- a/src/clutchtimealerts/db_utils.py
+++ b/src/clutchtimealerts/db_utils.py
@@ -222,7 +222,10 @@ def check_overtime_alert_sent(Session, gameid: str, overtime_number: int) -> boo
     try:
         game = (
             session.query(ClutchGame)
-            .filter_by(gameid=gameid, overtime_alert_number=overtime_number)
+            .filter(
+                (ClutchGame.gameid == gameid)
+                & (ClutchGame.overtime_alert_number >= overtime_number)
+            )
             .first()
         )
         return game is not None

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -122,12 +122,14 @@ def test_check_overtime_alert_sent(db_name):
     assert not check_overtime_alert_sent(Session, gameid, 1)
 
     update_overtime_number(Session, gameid)
-    assert not check_overtime_alert_sent(Session, gameid, 0)
+    assert check_overtime_alert_sent(Session, gameid, 0)
     assert check_overtime_alert_sent(Session, gameid, 1)
+    assert not check_overtime_alert_sent(Session, gameid, 2)
 
     update_overtime_number(Session, gameid)
-    assert not check_overtime_alert_sent(Session, gameid, 1)
+    assert check_overtime_alert_sent(Session, gameid, 1)
     assert check_overtime_alert_sent(Session, gameid, 2)
+    assert not check_overtime_alert_sent(Session, gameid, 3)
 
 
 def test_update_overtime_number(db_name):


### PR DESCRIPTION
# Overview

This PR fixes a bug resulting in multiple alerts for OT. This was caused by OT check only checking for the most recent overtime period before incrementing the counter. If the API momentarily swapped back to old OT number the counter fell out of sync. The new check won't increment counter for previous OT period.

## Changes

- Updated database logic for checking OT in db_utils.py (now returns true if OT alert is greater than or larger)
- Updated corresponding unit tests
- Updated to version 0.2.1