### PR TITLE
21 enhancement disable preseason alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ license = {text = "MIT"}
 
 
 [dependency-groups]
-lint = ["pre-commit>=4.0.1", "ruff>=0.8.6"]
+lint = [
+    "pre-commit>=4.0.1",
+    "ruff>=0.8.6",
+]
 tests = [
     "pytest>=8.3.4",
 ]

--- a/src/clutchtimealerts/config_parser.py
+++ b/src/clutchtimealerts/config_parser.py
@@ -39,6 +39,7 @@ NBA_TRICODES = {
     "UTA",  # Utah Jazz
     "WAS",  # Washington Wizards
 }
+DEFAULT_PRESEASON = False
 
 
 class ConfigParser:
@@ -66,6 +67,7 @@ class ConfigParser:
         )
         ot_format = config.get("ot_format", DEFAULT_OT_FORMAT)
         team_config = set(config.get("nba_teams", NBA_TRICODES))
+        preseason = config.get("preseason", DEFAULT_PRESEASON)
 
         notification_yaml: list[dict] = config.get("notifications", [])
         self.notification_configs = []
@@ -126,6 +128,7 @@ class ConfigParser:
                 ),
                 ot_format=notify_config.get("ot_format", ot_format),
                 nba_teams=notification_team_config,
+                preseason=notify_config.get("preseason", preseason),
             )
             self.notification_configs.append(notification_config)
 

--- a/src/clutchtimealerts/notifications/base.py
+++ b/src/clutchtimealerts/notifications/base.py
@@ -16,3 +16,4 @@ class NotificationConfig:
     notification_format: str
     ot_format: str
     nba_teams: set[str]
+    preseason: bool = False

--- a/tests/test_clutch_alerts.py
+++ b/tests/test_clutch_alerts.py
@@ -1,0 +1,153 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from clutchtimealerts.clutch_alerts import ClutchAlertsService
+from clutchtimealerts.notifications.base import NotificationConfig
+
+
+@pytest.fixture
+def mock_notification_config():
+    config = MagicMock(spec=NotificationConfig)
+    config.nba_teams = ["LAL", "BOS"]
+    config.preseason = False
+    config.notification_format = "clutch format"
+    config.ot_format = "ot format"
+    config.notification = MagicMock()
+    config.notification.send = MagicMock()
+    return config
+
+
+@pytest.fixture
+def sample_game():
+    return {
+        "gameId": "12345",
+        "homeTeam": {"teamTricode": "LAL", "score": 100},
+        "awayTeam": {"teamTricode": "BOS", "score": 98},
+        "period": 4,
+        "gameClock": "PT04M30S",
+        "gameLabel": "Regular Season",
+    }
+
+
+def test_get_minutes_from_clock_valid():
+    service = ClutchAlertsService([])
+    assert service._get_minutes_from_clock("PT04M30S") == 4
+    assert service._get_minutes_from_clock("PT12M00S") == 12
+
+
+def test_get_minutes_from_clock_invalid():
+    service = ClutchAlertsService([])
+    assert service._get_minutes_from_clock("") == -1
+    assert service._get_minutes_from_clock("INVALID") == -1
+
+
+def test_is_clutch_time_true(sample_game):
+    service = ClutchAlertsService([])
+    assert service.isCluthTime(sample_game) is True
+
+
+def test_is_clutch_time_false_period(sample_game):
+    service = ClutchAlertsService([])
+    sample_game["period"] = 3
+    assert service.isCluthTime(sample_game) is False
+
+
+def test_is_clutch_time_false_minutes(sample_game):
+    service = ClutchAlertsService([])
+    sample_game["gameClock"] = "PT06M00S"
+    assert service.isCluthTime(sample_game) is False
+
+
+def test_is_clutch_time_false_score_diff(sample_game):
+    service = ClutchAlertsService([])
+    sample_game["awayTeam"]["score"] = 90
+    assert service.isCluthTime(sample_game) is False
+
+
+def test_is_preseason_true(sample_game):
+    service = ClutchAlertsService([])
+    sample_game["gameLabel"] = "Preseason"
+    assert service.isPreseason(sample_game) is True
+
+
+def test_is_preseason_false(sample_game):
+    service = ClutchAlertsService([])
+    assert service.isPreseason(sample_game) is False
+
+
+def test_is_overtime_true(sample_game):
+    service = ClutchAlertsService([])
+    sample_game["period"] = 5
+    assert service.isOvertime(sample_game) is True
+
+
+def test_is_overtime_false(sample_game):
+    service = ClutchAlertsService([])
+    sample_game["period"] = 4
+    assert service.isOvertime(sample_game) is False
+
+
+@patch("clutchtimealerts.clutch_alerts.format_message")
+def test_send_alert_clutch(mock_format_message, mock_notification_config, sample_game):
+    mock_format_message.return_value = "formatted message"
+    service = ClutchAlertsService([mock_notification_config])
+
+    service.send_alert(sample_game, "clutch")
+
+    mock_format_message.assert_called_once_with(
+        sample_game, mock_notification_config.notification_format
+    )
+    mock_notification_config.notification.send.assert_called_once_with(
+        "formatted message"
+    )
+
+
+@patch("clutchtimealerts.clutch_alerts.format_message")
+def test_send_alert_ot(mock_format_message, mock_notification_config, sample_game):
+    mock_format_message.return_value = "ot message"
+    service = ClutchAlertsService([mock_notification_config])
+
+    service.send_alert(sample_game, "ot")
+
+    mock_format_message.assert_called_once_with(
+        sample_game, mock_notification_config.ot_format
+    )
+    mock_notification_config.notification.send.assert_called_once_with("ot message")
+
+
+def test_send_alert_skips_non_teams(mock_notification_config, sample_game):
+    service = ClutchAlertsService([mock_notification_config])
+    sample_game["homeTeam"]["teamTricode"] = "NYK"
+    sample_game["awayTeam"]["teamTricode"] = "MIA"
+
+    service.send_alert(sample_game, "clutch")
+
+    mock_notification_config.notification.send.assert_not_called()
+
+
+def test_send_alert_skips_non_preseason(mock_notification_config, sample_game):
+    service = ClutchAlertsService([mock_notification_config])
+    sample_game["gameLabel"] = "Preason"
+
+    service.send_alert(sample_game, "clutch")
+
+    mock_notification_config.notification.send.assert_not_called()
+
+
+@patch("clutchtimealerts.clutch_alerts.format_message")
+def test_send_alert_sends_if_preseason_enabled(
+    mock_format_message, mock_notification_config, sample_game
+):
+    mock_format_message.return_value = "formatted message"
+    mock_notification_config.preseason = True
+
+    service = ClutchAlertsService([mock_notification_config])
+
+    sample_game["gameLabel"] = "Preason"
+    service.send_alert(sample_game, "clutch")
+
+    mock_format_message.assert_called_once_with(
+        sample_game, mock_notification_config.notification_format
+    )
+    mock_notification_config.notification.send.assert_called_once_with(
+        "formatted message"
+    )

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -4,6 +4,7 @@ from clutchtimealerts.config_parser import (
     ConfigParser,
     DEFAULT_NOTIFICATION_FORMAT,
     DEFAULT_OT_FORMAT,
+    DEFAULT_PRESEASON,
     NBA_TRICODES,
 )
 from clutchtimealerts.notifications.base import Notification
@@ -397,6 +398,29 @@ def test_parse_default_nba_teams(
 
 @patch("yaml.safe_load")
 @patch("builtins.open", new_callable=mock_open)
+def test_parse_default_preseason(
+    mock_open_file, mock_yaml_load, classname_dict, common_name_dict
+):
+    """Test config with no notification format."""
+    mock_yaml_load.return_value = {
+        "notifications": [
+            {"type": "email", "config": {"recipient": "test@example.com"}},
+            {"type": "sms", "config": {"phone_number": "+123456789"}},
+        ],
+    }
+    parser = ConfigParser(
+        config_path="test_config.yaml",
+        classname_dict=classname_dict,
+        common_name_dict=common_name_dict,
+    )
+    parser.parse_config()
+
+    assert parser.notification_configs[0].preseason == DEFAULT_PRESEASON
+    assert parser.notification_configs[1].preseason == DEFAULT_PRESEASON
+
+
+@patch("yaml.safe_load")
+@patch("builtins.open", new_callable=mock_open)
 def test_parse_global_nba_teams(
     mock_open_file, mock_yaml_load, classname_dict, common_name_dict
 ):
@@ -480,3 +504,27 @@ def test_parse_invalid_specific_nba_teams(
     mock_warning.assert_called_once_with(
         "No teams specified for notification type email defaulting to all teams"
     )
+
+
+@patch("yaml.safe_load")
+@patch("builtins.open", new_callable=mock_open)
+def test_parse_global_preseason(
+    mock_open_file, mock_yaml_load, classname_dict, common_name_dict
+):
+    """Test config with no notification format."""
+    mock_yaml_load.return_value = {
+        "preseason": True,
+        "notifications": [
+            {"type": "email", "config": {"recipient": "test@example.com"}},
+            {"type": "sms", "config": {"phone_number": "+123456789"}},
+        ],
+    }
+    parser = ConfigParser(
+        config_path="test_config.yaml",
+        classname_dict=classname_dict,
+        common_name_dict=common_name_dict,
+    )
+    parser.parse_config()
+
+    assert parser.notification_configs[0].preseason
+    assert parser.notification_configs[1].preseason


### PR DESCRIPTION
# Overview

Added the abilitiy disabled and enable preseason alerts. By default they will be disabled going forward unless specified at global or per notification level.

# Changes

- Updated config parser to include preseason 
- Updated notification configs to have preseason field
- Updated ClutchAlertsService to have sending logic for preseason and have isPreseason function