### PR TITLE
Plugin Support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Brian Walheim
+Copyright (c) 2025 Brian Walheim
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -165,3 +165,42 @@ python3 -m clutchtimealerts -f <path-to-config>
 ```sh
 docker run -v <path-to-config>:/app/config.yml clutchtimealerts
 ```
+
+# Plugins
+
+Is there a notification type we don't currently support? You can add your own by writing a notification plugin. No need to fork this recipe just create your own plugin project and install it.
+
+## Writing Your Own Notification Plugin
+
+To create a plugin:
+
+1. Implement a subclass of `Notification`.
+2. Give it a `COMMON_NAME`.
+3. Expose it via an entry point in your `pyproject.toml`.
+
+Example:
+
+`plugin_example.py`:
+
+```python
+from clutchtimealerts.notifications.base import Notification
+
+class PluginNotification(Notification):
+    COMMON_NAME = "Plugin"
+
+    def send(self, message: str):
+        # Custom Send Logic
+        pass
+
+```
+
+`pyproject.toml`:
+
+```toml
+[project.entry-points."clutchtimealerts.notification_plugins"]
+plugin = "plugin_example:PluginNotification"
+```
+
+You can see a complete working example in the example plugin project:
+
+**Example plugin:** https://github.com/bwalheim1205/clutchtimealerts-example-plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "MIT"}
 
-
 [dependency-groups]
 lint = [
     "pre-commit>=4.0.1",
@@ -33,3 +32,5 @@ ignore = ["E501"]
 [tool.pdm]
 distribution = true
 
+# Adding extry point for plugins
+[project.entry-points."clutchtimealerts.notification_plugins"]

--- a/src/clutchtimealerts/config_parser.py
+++ b/src/clutchtimealerts/config_parser.py
@@ -77,7 +77,7 @@ class ConfigParser:
 
             # Get YAML Config
             notifiction_type = notify_config["type"]
-            class_config = notify_config["config"]
+            class_config = notify_config.get("config", {})
             notification_team_config = NBA_TRICODES.intersection(
                 set(notify_config.get("nba_teams", team_config))
             )


### PR DESCRIPTION
# Overview

This MR allows for notification plugins. People can now add there own custom notification types without needing to fork the repository. This is done using the `[project.entry-points."clutchtimealerts.notification_plugins"]` entrypoint in pyproject.toml

# Changes

- Updated notification_collector.py to include plugins and updated corresponding test
- Added entrypoint to pyproject.toml
- Made config field completely option
- Updated README.md with basic plugin instructions and link to example plugin
- Updated year on license

# Issues

Closes #26 